### PR TITLE
Fixes for Python3 Popen returing bytes on top of python-libs PR 17

### DIFF
--- a/tests/test_biosdevname.py
+++ b/tests/test_biosdevname.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from mock import patch, Mock
 
@@ -27,9 +28,11 @@ class TestQuirks(unittest.TestCase):
 class TestDeviceNames(unittest.TestCase):
     def test(self):
         with patch("xcp.net.biosdevname.Popen") as popen_mock:
-            with open("tests/data/physical.biosdevname") as f:
+            # Python3 Popen().stdout.__iter__ returns bytes. Mock it using mode='rb':
+            popen_mode = 'r' if sys.version_info.major == 2 else 'rb'
+            with open("tests/data/physical.biosdevname", popen_mode) as f:
                 fake_output_1 = f.read()
-            with open("tests/data/all_ethN.biosdevname") as f:
+            with open("tests/data/all_ethN.biosdevname", popen_mode) as f:
                 fake_output_2 = f.read()
             communicate_mock = Mock(side_effect=iter([(fake_output_1, ""),
                                                       (fake_output_2, "")]))

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from mock import patch, Mock, DEFAULT
 
@@ -30,12 +31,18 @@ class TestCache(unittest.TestCase):
             self.assertEqual(data, "line1\nline2\n")
 
     def test_runCmd(self):
-        output_data = "line1\nline2\n"
+        mock_popen_stdout = expected_stdout = "line1\nline2\n"
+        mock_popen_stderr = expected_stderr = "mock error"
+        # Python3 Popen().communicate() returns a tuple of bytes:
+        if sys.version_info.major != 2:
+            mock_popen_stdout = expected_stdout.encode()
+            mock_popen_stderr = expected_stderr.encode()
+
         with patch("xcp.cmd.subprocess.Popen") as popen_mock:
             # mock Popen .communicate and .returncode for
-            # `output_data`on stdout, nothing on stderr, and exit
+            # `mock_popen_stdout`on stdout, `mock_popen_stderr` on stderr, and an exit
             # value of 42
-            communicate_mock = Mock(return_value=(output_data, ""))
+            communicate_mock = Mock(return_value=(mock_popen_stdout, mock_popen_stderr))
             popen_mock.return_value.communicate = communicate_mock
             def communicate_side_effect(_input_text):
                 popen_mock.return_value.returncode = 42
@@ -45,10 +52,10 @@ class TestCache(unittest.TestCase):
             # uncached runCmd
             data = self.c.runCmd(['ls', '/tmp'], True)
             popen_mock.assert_called_once()
-            self.assertEqual(data, (42, output_data))
+            self.assertEqual(data, (42, expected_stdout))
 
             # rerun as cached
             popen_mock.reset_mock()
-            data = self.c.runCmd(['ls', '/tmp'], True)
+            data = self.c.runCmd(['ls', '/tmp'], with_stdout=True, with_stderr=True)
             popen_mock.assert_not_called()
-            self.assertEqual(data, (42, output_data))
+            self.assertEqual(data, (42, expected_stdout, expected_stderr))

--- a/xcp/cmd.py
+++ b/xcp/cmd.py
@@ -41,9 +41,11 @@ def runCmd(command, with_stdout = False, with_stderr = False, inputtext = None):
     l = "ran %s; rc %d" % (str(command), rv)
     if inputtext:
         l += " with input %s" % inputtext
-    if out != "":
+    if out:
+        out = out.decode()
         l += "\nSTANDARD OUT:\n" + out
-    if err != "":
+    if err:
+        err = err.decode()
         l += "\nSTANDARD ERROR:\n" + err
 
     for line in l.split('\n'):

--- a/xcp/net/biosdevname.py
+++ b/xcp/net/biosdevname.py
@@ -65,7 +65,7 @@ def all_devices_all_names():
         if retcode:
             continue
 
-        for device in (x.strip() for x in stdout.split("\n\n") if len(x)):
+        for device in (x.strip() for x in stdout.decode().split("\n\n") if len(x)):
             dinfo = {}
 
             for l in device.split("\n"):

--- a/xcp/pci.py
+++ b/xcp/pci.py
@@ -259,7 +259,7 @@ class PCIDevices(object):
                                stdout = subprocess.PIPE)
         for l in cmd.stdout:
             line = l.rstrip()
-            el = [x for x in line.replace('"', '').split() if not x.startswith('-')]
+            el = [x for x in line.decode().replace('"', '').split() if not x.startswith('-')]
             self.devs[el[0]] = {'id': el[0],
                                 'class': el[1][:2],
                                 'subclass': el[1][2:],


### PR DESCRIPTION
@alexhimmel: Initial preview of the fixes you may need.

This should allow porting ACK from Python2 to Python3

Status:
* Passes `python2 -m pytest`
* TODO: Fix `python3 -m pytest` with the outstanding fixes for python-libs PR 17.