### PR TITLE
Testsuite driven py3 encoding

### DIFF
--- a/tests/data/pci.ids
+++ b/tests/data/pci.ids
@@ -11,6 +11,8 @@
 	1314  Wrestler HDMI Audio
 		174b 1001  PURE Fusion Mini
 	1636  Renoir
+	67b0  Hawaii XT / Grenada XT [Radeon R9 290X/390X]
+		1787 2020  R9 290X IceQ X² Turbo
 	7340  Navi 14 [Radeon RX 5500/5500M / Pro 5500M]
 
 # List of known device classes, subclasses and programming interfaces

--- a/tests/test_biosdevname.py
+++ b/tests/test_biosdevname.py
@@ -1,6 +1,8 @@
+import subprocess
 import unittest
 from mock import patch, Mock
 
+from xcp import xcp_popen_text_kwargs
 from xcp.net.biosdevname import has_ppn_quirks, all_devices_all_names
 
 class TestQuirks(unittest.TestCase):
@@ -40,6 +42,11 @@ class TestDeviceNames(unittest.TestCase):
 
         # check after the fact that we mocked the proper calls
         self.assertEqual(popen_mock.call_count, 2)
+        popen_mock.assert_called_with(['/sbin/biosdevname', '--policy', 'all_ethN', '-d'],
+                                      stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE,
+                                      **xcp_popen_text_kwargs)
+
         calls = popen_mock.call_args_list
         self.assertEqual(calls[0].args[0], ['/sbin/biosdevname', '--policy', 'physical', '-d'])
         self.assertEqual(calls[1].args[0], ['/sbin/biosdevname', '--policy', 'all_ethN', '-d'])

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -66,3 +66,9 @@ class TestCache(unittest.TestCase):
             data = self.c.runCmd(['ls', '/tmp'], with_stdout=True, with_stderr=True)
             popen_mock.assert_not_called()
             self.assertEqual(data, (42, output_data, stderr_data))
+
+    def test_runCmdCatStdin(self):
+        """Call cat with a given UTF-8 input text and expect it to be returned"""
+        stdin = "output with\nUTF-8:\u25b6\U0001f601"
+        ret = self.c.runCmd("cat", inputtext=stdin, with_stdout=True, with_stderr=True)
+        self.assertEqual(ret, (0, stdin, ""))

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -37,12 +37,13 @@ class TestCache(unittest.TestCase):
 
     def test_runCmd(self):
         output_data = "output with\nUTF-8:\u25b6\U0001f601\n"
+        stderr_data = "error with\nUTF-8:\u2614\U0001f629\n"
 
         with patch("xcp.cmd.subprocess.Popen") as popen_mock:
             # mock Popen .communicate and .returncode for
-            # `output_data`on stdout, nothing on stderr, and exit
+            # `output_data` on stdout, `stderr_data` on stderr, and an exit
             # value of 42
-            communicate_mock = Mock(return_value=(output_data, ""))
+            communicate_mock = Mock(return_value=(output_data, stderr_data))
             popen_mock.return_value.communicate = communicate_mock
             def communicate_side_effect(_input_text):
                 popen_mock.return_value.returncode = 42
@@ -62,6 +63,6 @@ class TestCache(unittest.TestCase):
 
             # rerun as cached
             popen_mock.reset_mock()
-            data = self.c.runCmd(['ls', '/tmp'], True)
+            data = self.c.runCmd(['ls', '/tmp'], with_stdout=True, with_stderr=True)
             popen_mock.assert_not_called()
-            self.assertEqual(data, (42, output_data))
+            self.assertEqual(data, (42, output_data, stderr_data))

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,6 +1,8 @@
+import subprocess
 import unittest
 from mock import patch, Mock, DEFAULT
 
+from xcp import xcp_popen_text_kwargs
 from xcp.cmd import OutputCache
 
 class TestCache(unittest.TestCase):
@@ -44,7 +46,13 @@ class TestCache(unittest.TestCase):
 
             # uncached runCmd
             data = self.c.runCmd(['ls', '/tmp'], True)
-            popen_mock.assert_called_once()
+            popen_mock.assert_called_once_with(["ls", "/tmp"],
+                                               bufsize=1,
+                                               stdin=None,
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.PIPE,
+                                               shell=False,
+                                               **xcp_popen_text_kwargs)
             self.assertEqual(data, (42, output_data))
 
             # rerun as cached

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -5,6 +5,10 @@ from mock import patch, Mock, DEFAULT
 from xcp import xcp_popen_text_kwargs
 from xcp.cmd import OutputCache
 
+from .xcptestlib import set_c_locale
+
+set_c_locale()
+
 class TestCache(unittest.TestCase):
     def setUp(self):
         self.c = OutputCache()
@@ -32,7 +36,8 @@ class TestCache(unittest.TestCase):
             self.assertEqual(data, "line1\nline2\n")
 
     def test_runCmd(self):
-        output_data = "line1\nline2\n"
+        output_data = "output with\nUTF-8:\u25b6\U0001f601\n"
+
         with patch("xcp.cmd.subprocess.Popen") as popen_mock:
             # mock Popen .communicate and .returncode for
             # `output_data`on stdout, nothing on stderr, and exit

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -1,0 +1,45 @@
+# Unit test for xcp/net/ip.py
+import unittest
+from subprocess import PIPE
+
+from mock import Mock, patch
+
+import xcp.net.ip
+from xcp import xcp_popen_text_kwargs
+
+
+class TestIp(unittest.TestCase):
+    def test_ip_link_set_name(self):
+        with patch("xcp.net.ip.Popen") as popen_mock:
+
+            # Setup the return values and return codes returned by popen_mock:
+            ip_link_show_lo_stdout = (
+                "1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state"
+                "UNKNOWN mode DEFAULT group default qlen 1000"
+            )
+            communicate_mock = Mock(
+                side_effect=iter([(ip_link_show_lo_stdout, ""), ("", "")])
+            )
+            popen_mock.return_value.communicate = communicate_mock
+            popen_mock.return_value.returncode = 0
+
+            # Call the testee function with xcp.net.ip.Popen() mocked using popen_mock:
+            xcp.net.ip.ip_link_set_name("lo", "lo0")
+
+        # check the number or calls to Popen() by done by ip_link_set_name()
+        self.assertEqual(popen_mock.call_count, 4)
+
+        # check the captured regular arguments passed to Popen() by ip_link_set_name()
+        calls = popen_mock.call_args_list
+        self.assertEqual(calls[0].args, (["ip", "link", "show", "lo"],))
+        self.assertEqual(calls[1].args, (["ip", "link", "set", "lo", "down"],))
+        self.assertEqual(calls[2].args, (["ip", "link", "set", "lo", "name", "lo0"],))
+        self.assertEqual(calls[3].args, (["ip", "link", "set", "lo0", "up"],))
+
+        # check the captured keyword arguments passed to Popen() by ip_link_set_name()
+        xcp_popen_text_kwargs_stdout = xcp_popen_text_kwargs.copy()
+        xcp_popen_text_kwargs_stdout["stdout"] = PIPE
+        self.assertEqual(calls[0].kwargs, xcp_popen_text_kwargs_stdout)
+        self.assertEqual(calls[1].kwargs, xcp_popen_text_kwargs)
+        self.assertEqual(calls[2].kwargs, xcp_popen_text_kwargs)
+        self.assertEqual(calls[3].kwargs, xcp_popen_text_kwargs)

--- a/tests/test_pci.py
+++ b/tests/test_pci.py
@@ -101,7 +101,31 @@ class TestPCIIds(unittest.TestCase):
                                            **xcp_popen_text_kwargs)
         sorted_devices = sorted(devs.findByClass(video_class),
                                 key=lambda x: x['id'])
+
+        # Check the content of sorted_devices:
         self.assertEqual(len(sorted_devices), 2)
+        expected = [
+            {
+                "id": "03:00.0",
+                "class": "03",
+                "subclass": "80",
+                "vendor": "1002",
+                "device": "7340",
+                "subvendor": "1462",
+                "subdevice": "12ac",
+            },
+            {
+                "id": "07:00.0",
+                "class": "03",
+                "subclass": "00",
+                "vendor": "1002",
+                "device": "1636",
+                "subvendor": "1462",
+                "subdevice": "12ac",
+            },
+        ]
+        for device in [0, 1]:
+            self.assertDictEqual(expected[device], sorted_devices[device])
 
         for (video_dev,
              num_functions,

--- a/tests/test_pci.py
+++ b/tests/test_pci.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import unittest
 from mock import patch, Mock
 
@@ -78,6 +79,14 @@ class TestPCIIds(unittest.TestCase):
         open_mock.assert_called_once_with("/usr/share/hwdata/pci.ids", **xcp_popen_text_kwargs)
         video_class = ids.lookupClass('Display controller')
         self.assertEqual(video_class, ['03'])
+
+        # Check reading devices with UTF-8 chars:
+        if sys.version_info.major > 2:
+            self.assertEqual(ids.findSubdevice(1787, 2020), "R9 290X IceQ X\u00b2 Turbo")
+        else:
+            # Python2 would have to change the return value to unicode to return Unicode,
+            # so it returns the original UTF-8 string from the file:
+            self.assertEqual(ids.findSubdevice(1787, 2020), "R9 290X IceQ X\xc2\xb2 Turbo")
 
         with patch("xcp.pci.subprocess.Popen") as popen_mock, \
              open("tests/data/lspci-mn", **xcp_popen_text_kwargs) as fake_data:

--- a/tests/test_pci.py
+++ b/tests/test_pci.py
@@ -6,6 +6,10 @@ from mock import patch, Mock
 from xcp import xcp_popen_text_kwargs
 from xcp.pci import PCI, PCIIds, PCIDevices
 
+from .xcptestlib import set_c_locale
+
+set_c_locale()
+
 class TestInvalid(unittest.TestCase):
 
     def test_invalid_types(self):

--- a/tests/xcptestlib.py
+++ b/tests/xcptestlib.py
@@ -1,0 +1,19 @@
+import locale
+
+# We might be called with the locale not set, in which case python2's default
+# charset is ASCII. This happens when code is running as an xapi-plugin.
+# In this case any decode() calls added for Python3, which could (wrongly)
+# be also used when running in Python2, at least have to use encoding="utf-8",
+# or they will raise Exceptions. Test this worst-case scenario.
+# For reference, see the explanations here:
+# https://stackoverflow.com/questions/40029017/python2-using-decode-with-errors-replace-still-returns-errors
+def set_c_locale():
+    """
+    Disable any UTF-8 locale setting to ensure that when decode() gets
+    non-ASCII data do decode, it has the arg encoding="utf-8", otherwise
+    it would raise UnicodeDecodeError which would abort the calling program.
+    Likewise, this can catch wrong uses of encode(**args) on strings which would
+    trigger the sequence of string.decode().encode(**args) internally, likwise
+    raising UnicodeDecodeError in the .decode() step:
+    """
+    locale.setlocale(locale.LC_ALL, 'C')

--- a/xcp/__init__.py
+++ b/xcp/__init__.py
@@ -22,3 +22,51 @@
 # ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+# Introduction on making the popen() calls compatible with Python3:
+# =================================================================
+#
+# The xcp-python library uses popen() at nine occasions and in contrast
+# to open() which has io.open(file, encoding="utf-8", errors="replace"),
+# for compatible support for both Python2 and Python3, there does not
+# appear to be a similar common function for subprocess.Popen*() which
+# has these characteristics:
+#
+# Python2:
+# --------
+# On Python2, "str" is the same as bytes. Thus, there is no conversion,
+# and no issue. It just passes data in and out unmodified.
+#
+# Python3:
+# --------
+# Unless enabled by extra arguments, Popen() operates in binary mode.
+# In binary mode, it expects bytes for stdin, and returns bytes from stdout and stderr.
+#
+# Thus, bytes need to be converted to strings at some point:
+#
+# The simplest way to do this is to let Popen() do the encoding and decoding
+# of stdin, stdout and stderr. It does this when text mode is enabled using
+# the encoding parameter. Since XCP uses LANG=en_US.UTF-8, encoding="utf-8".
+#
+# Also, when input or output bytes to/from the Pipes are malformed, this needs
+# to be handled. Instead of terminating the program by raising UnicodeDecodeError
+# or removing malformed bytes during conversion, replace them with question marks.
+#
+
+#
+# popen_utf8_text_kwargs is used as **xcp.popen_utf8_text_kwargs in the lib and tests
+# as well as for mocking of the calls and verification of the expected calls.
+# In total, it has to be used 9 times x 3 occurences, so 27 times in total.#
+#
+# For more information on Unicode handling and codec errors see:
+# https://www.honeybadger.io/blog/python-character-encoding/
+# https://johnlekberg.com/blog/2020-04-03-codec-errors.html
+#
+if sys.version_info.major > 2:
+    xcp_popen_text_kwargs = {"encoding": "utf-8", "errors": "replace"}
+else:
+    xcp_popen_text_kwargs = {}
+
+# This can then be used like this: Popen(exe, ..., **xcp.open_utf8_test_kwargs)

--- a/xcp/cmd.py
+++ b/xcp/cmd.py
@@ -27,13 +27,16 @@ import subprocess
 import six
 
 import xcp.logger as logger
+from xcp import xcp_popen_text_kwargs
+
 
 def runCmd(command, with_stdout = False, with_stderr = False, inputtext = None):
     cmd = subprocess.Popen(command, bufsize=1,
                            stdin=(inputtext and subprocess.PIPE or None),
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE,
-                           shell=isinstance(command, six.string_types))
+                           shell=isinstance(command, six.string_types),
+                           **xcp_popen_text_kwargs)
 
     (out, err) = cmd.communicate(inputtext)
     rv = cmd.returncode

--- a/xcp/net/biosdevname.py
+++ b/xcp/net/biosdevname.py
@@ -33,6 +33,8 @@ __author__ = "Andrew Cooper"
 
 from subprocess import Popen, PIPE
 
+from xcp import xcp_popen_text_kwargs
+
 __ALL_POLICIES = [ "physical", "all_ethN" ]
 
 def __run_all_devices(policy = "physical"):
@@ -42,7 +44,7 @@ def __run_all_devices(policy = "physical"):
     """
 
     proc = Popen(["/sbin/biosdevname", "--policy", policy,
-                  "-d"], stdout=PIPE, stderr=PIPE)
+                  "-d"], stdout=PIPE, stderr=PIPE, **xcp_popen_text_kwargs)
 
     stdout, stderr = proc.communicate()
 

--- a/xcp/net/ip.py
+++ b/xcp/net/ip.py
@@ -32,6 +32,7 @@ __author__ = "Andrew Cooper"
 
 from subprocess import Popen, PIPE
 
+from xcp import xcp_popen_text_kwargs
 from xcp.logger import LOG
 
 # Deal with lack of environment more sensibly than hard coding /sbin/ip
@@ -53,7 +54,8 @@ def ip_link_set_name(src_name, dst_name):
     LOG.debug("Attempting rename %s -> %s" % (src_name, dst_name))
 
     # Is the interface currently up?
-    link_show = Popen(["ip", "link", "show", src_name], stdout = PIPE)
+    link_show = Popen(["ip", "link", "show", src_name], stdout = PIPE, **xcp_popen_text_kwargs)
+
     stdout, _ = link_show.communicate()
 
     if link_show.returncode != 0:
@@ -66,7 +68,7 @@ def ip_link_set_name(src_name, dst_name):
 
     # If it is up, bring it down for the rename
     if isup:
-        link_down = Popen(["ip", "link", "set", src_name, "down"])
+        link_down = Popen(["ip", "link", "set", src_name, "down"], **xcp_popen_text_kwargs)
         link_down.wait()
 
         if link_down.returncode != 0:
@@ -75,7 +77,7 @@ def ip_link_set_name(src_name, dst_name):
             return
 
     # Perform the rename
-    link_rename = Popen(["ip", "link", "set", src_name, "name", dst_name])
+    link_rename = Popen(["ip", "link", "set", src_name, "name", dst_name], **xcp_popen_text_kwargs)
     link_rename.wait()
 
     if link_rename.returncode != 0:
@@ -91,7 +93,7 @@ def ip_link_set_name(src_name, dst_name):
         # its final name.  However, i cant think of a non-hacky way of doing
         # this with the current implementation
 
-        link_up = Popen(["ip", "link", "set", dst_name, "up"])
+        link_up = Popen(["ip", "link", "set", dst_name, "up"], **xcp_popen_text_kwargs)
         link_up.wait()
 
         if link_up.returncode != 0:

--- a/xcp/pci.py
+++ b/xcp/pci.py
@@ -26,6 +26,8 @@ import subprocess
 import re
 import six
 
+from xcp import xcp_popen_text_kwargs
+
 _SBDF = (r"(?:(?P<segment> [\da-dA-F]{4}):)?" # Segment (optional)
          r"     (?P<bus>     [\da-fA-F]{2}):"   # Bus
          r"     (?P<device>  [\da-fA-F]{2})\."  # Device
@@ -185,7 +187,8 @@ class PCIIds(object):
         vendor = None
         cls = None
 
-        fh = open(fn)
+        # Enable text mode with UTF-8. On errors, replace malformed bytes with "?":
+        fh = open(fn, **xcp_popen_text_kwargs)
         for l in fh:
             line = l.rstrip()
             if line == '' or line.startswith('#'):
@@ -256,7 +259,8 @@ class PCIDevices(object):
         self.devs = {}
 
         cmd = subprocess.Popen(['lspci', '-mn'], bufsize = 1,
-                               stdout = subprocess.PIPE)
+                               stdout = subprocess.PIPE,
+                               **xcp_popen_text_kwargs)
         for l in cmd.stdout:
             line = l.rstrip()
             el = [x for x in line.replace('"', '').split() if not x.startswith('-')]


### PR DESCRIPTION
This PR builds on top of testsuite-driven-py3, the commits in this PR are:

Introduce xcp.xcp_popen_text_kwargs and use it for Popen and open
----    
Also use xcp.xcp_popen_text_kwargs for all affected unit tests
because they need to handle the encoding decode/encode likewise.

tests/test_pci.py: Test that xcp.pci can handle UTF-8 in hwinfo/pci.ids
---- 
Now we use encoding="utf-8" to open /usr/share/hwdata/pci.ids,
enhance the test case to ensure that xcp.pci does not crash when
the existing UTF-8 characters in /usr/share/hwdata/pci.ids are
included in the unit test and returns the expected output.

Test that where required, xcp.pci and xcp.cmd support LC_CTYPE=C
----
We might be called with the locale not set, in which case python2's default
charset is ASCII. This happens when code is running as an xapi-plugin.
    
For example, this happens with the ACK plugin which uses xcp.pci.PCIIds()
    
This means we have to test that the code uses encoding="utf-8" correctly
in all cases (python2 and python3) and this test adds testing this while
processing UTF-8 data in xcp.cmd and xcp.pci.PCIIds().read()
    
tests/test_cmd.py: Full test for stdin/stdout (UTF-8) using "cat"
----
tests/test_cmd.py: Also test UTF-8 in stderr of the cmd
----
tests/test_pci.py: Verify the returned Dict to have expected content.
----